### PR TITLE
feat: cpin list with no args shows all project notes

### DIFF
--- a/include/fileio.h
+++ b/include/fileio.h
@@ -46,4 +46,9 @@ cpin_error_t fileio_load(char* file, char* line, char** result);
 // Returns: CPIN_SUCCESS on success, or appropriate error code from error.h on failure
 cpin_error_t fileio_delete(char* file, char* line);
 
+// Loads all notes across the entire project into a newly allocated string (*result).
+// Caller must free(*result).
+// Returns: CPIN_SUCCESS on success, CPIN_ERR_NOTE_NOT_FOUND if no notes exist
+cpin_error_t fileio_load_all(char** result);
+
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -132,6 +132,45 @@ cpin_error_t fileio_load(char* file, char* line, char** result) {
     return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
 }
 
+// Loads all notes from .cpin/notes into a newly allocated string (*result).
+// Caller must free(*result).
+cpin_error_t fileio_load_all(char** result) {
+    if (!result) return CPIN_ERR_INVALID_ARGS;
+    *result = NULL;
+
+    FILE* f = fopen(CPIN_NOTES, "r");
+    if (!f) return CPIN_ERR_NOTE_NOT_FOUND;
+
+    char buf[4096];
+    char* out = NULL;
+    size_t out_len = 0;
+
+    while (fgets(buf, sizeof(buf), f)) {
+        char tmp[4096];
+        strncpy(tmp, buf, sizeof(tmp) - 1);
+        tmp[sizeof(tmp) - 1] = '\0';
+
+        char *tok_file, *tok_line, *tok_content;
+        if (parse_line(tmp, &tok_file, &tok_line, &tok_content) != 0) continue;
+
+        char display[4096];
+        int n = snprintf(display, sizeof(display), "%s:%s:%s\n",
+                         tok_file, tok_line, tok_content);
+        if (n <= 0) continue;
+
+        char* tmp_out = realloc(out, out_len + (size_t)n + 1);
+        if (!tmp_out) { free(out); fclose(f); return CPIN_ERR_WRITE_FAILED; }
+        out = tmp_out;
+        memcpy(out + out_len, display, (size_t)n);
+        out_len += (size_t)n;
+        out[out_len] = '\0';
+    }
+
+    fclose(f);
+    *result = out;
+    return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
+}
+
 // Deletes all notes matching file:line from .cpin/notes (rewrites the file).
 cpin_error_t fileio_delete(char* file, char* line) {
     if (!file) return CPIN_ERR_INVALID_ARGS;

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@
 static void usage(void) {
     printf("Usage:\n");
     printf("  cpin add <file:line> \"<note>\"\n");
-    printf("  cpin list <file> [line]\n");
+    printf("  cpin list [file] [line]\n");
     printf("  cpin remove <file:line>\n");
 }
 
@@ -56,21 +56,26 @@ int main(int argc, char** argv) {
 
     // ── list ──────────────────────────────────────────────────────────────────
     if (!strcmp(cmd, "list")) {
-        if (argc < 3) {
-            printf("Usage: cpin list <file> [line]\n");
-            return 1;
-        }
-
-        char* file = argv[2];
-        char* line = (argc >= 4) ? argv[3] : NULL;
         char* result = NULL;
+        cpin_error_t err;
 
-        cpin_error_t err = fileio_load(file, line, &result);
-        if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
-            printf("No notes found for %s%s%s\n",
-                   file, line ? ":" : "", line ? line : "");
-            return 0;
+        if (argc < 3) {
+            err = fileio_load_all(&result);
+            if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
+                printf("No notes found in this project\n");
+                return 0;
+            }
+        } else {
+            char* file = argv[2];
+            char* line = (argc >= 4) ? argv[3] : NULL;
+            err = fileio_load(file, line, &result);
+            if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
+                printf("No notes found for %s%s%s\n",
+                       file, line ? ":" : "", line ? line : "");
+                return 0;
+            }
         }
+
         if (err != CPIN_SUCCESS) {
             printf("Error: %s\n", error_to_string(err));
             return 1;


### PR DESCRIPTION
## What does this PR do?                                                                                  
                                                                                                            
  Adds support for `cpin list` with no arguments. Previously the command required                           
  a file argument. Now, running it without arguments prints every note across the                         
  entire project by reading all entries from `.cpin/notes`.

  Closes #2

  ---

  ## Checklist

  - [x] Builds without errors (`make`)
  - [x] No compiler warnings (`-Wall -Wextra`)
  - [x] Tested manually (paste example commands and output below)
  - [x] Follows the code style in `CONTRIBUTING.md`
  - [ ] No memory leaks introduced (checked with `valgrind` or `AddressSanitizer` if applicable)

  ## Manual test

  ```bash
  # Add notes to two different files
  cpin add src/main.c:15 "why does this loop start at 1?"
  cpin add src/fileio.c:95 "loads notes matching file and line"

  # List all notes in the project (no args)
  cpin list
  # src/main.c:15:why does this loop start at 1?
  # src/fileio.c:95:loads notes matching file and line

  # File-specific list still works
  cpin list src/main.c
  # src/main.c:15:why does this loop start at 1?

  # No notes case
  cpin list
  # No notes found in this project

  Notes for reviewers

  Added fileio_load_all() in fileio.c and declared it in fileio.h.
  The list command in main.c now branches on whether a file argument
  was provided — no args calls fileio_load_all(), with a file calls the
  existing fileio_load(). Existing behavior is unchanged.