### PR TITLE
feat: add --global flag for user-level note storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,26 @@ lines and saves your notes localy without touching your source files.
 # Add a note to line 42 in parser.c
 cpin add src/parser.c:42 "why does this loop start at 1?"
 
+# Add a note to your global store (~/.cpin/notes)
+cpin add src/parser.c:42 "personal reminder" --global
+
 # List all notes for a specific file
 cpin list src/parser.c
+
+# List all notes in the global store
+cpin list --global
 
 # Remove a note from line 42 in parser.c
 cpin remove src/parser.c:42
 
+# Remove a note from the global store
+cpin remove src/parser.c:42 --global
 ```
+
+### `--global` flag
+By default, notes are stored in `.cpin/notes` inside your project directory.
+Pass `--global` to store notes in `~/.cpin/notes` instead — useful for personal
+reminders on files outside a project or notes you don't want committed.
 
 ## Installation
 
@@ -44,7 +57,7 @@ make uninstall     # may require sudo
 ### v0.2 — Search & Export
 - [ ] `cpin search <keyword>` — grep across all notes
 - [ ] `cpin export` — print notes as Markdown or JSON
-- [ ] Per-project (`.cpin/`) vs global (`~/.cpin/`) storage via flag
+- [x] Per-project (`.cpin/`) vs global (`~/.cpin/`) storage via `--global` flag
 
 ### v0.3 — Editor Integration
 - [ ] Git hook: warn when a noted line has moved or been deleted

--- a/include/fileio.h
+++ b/include/fileio.h
@@ -20,35 +20,31 @@ cpin_note_t fileio_create_note(char* file, char* line, char* content);
 // @note: pointer to the note structure to free (must not be NULL)
 void fileio_note_free(cpin_note_t* note);
 
+// Saves a note to the given notes file path
+// @node: the note to save
+// @notes_path: path to the notes file (local or global)
+// Returns: CPIN_SUCCESS on success, or appropriate error code on failure
+cpin_error_t fileio_save(cpin_note_t* node, const char* notes_path);
 
-// Initializes the hidden .cpin/ subdirectory for cpin configuration
-// Creates the necessary directory structure if it doesn't exist
-// Returns: CPIN_SUCCESS on success, or appropriate error code from error.h on failure
-cpin_error_t fileio_initialize(cpin_note_t* node);
+// Loads notes matching file (and optionally line) into a newly allocated string (*result).
+// @file: path to the file to filter by
+// @line: specific line number to filter by (can be NULL for entire file)
+// @notes_path: path to the notes file (local or global)
+// @result: pointer to store the loaded results — caller must free(*result)
+// Returns: CPIN_SUCCESS on success, or appropriate error code on failure
+cpin_error_t fileio_load(char* file, char* line, const char* notes_path, char** result);
 
-// Saves an individual node to the specified file and line location
-// @file: path to the file where the node should be saved
-// @line: line number in the file (can be NULL for default positioning)
-// @node: node identifier to save
-// Returns: CPIN_SUCCESS on success, or appropriate error code from error.h on failure
-cpin_error_t fileio_save(cpin_note_t* node);
-
-// Loads nodes from a specified file and optionally line
-// @file: path to the file to load from
-// @line: specific line number to load from (can be NULL for entire file)
-// @result: pointer to store the loaded results (must be pre-allocated)
-// Returns: CPIN_SUCCESS on success, or appropriate error code from error.h on failure
-cpin_error_t fileio_load(char* file, char* line, char** result);
-
-// Deletes a specified node from the file:line format
-// @file: path to the file containing the node
-// @line: line number where the note is located
-// Returns: CPIN_SUCCESS on success, or appropriate error code from error.h on failure
-cpin_error_t fileio_delete(char* file, char* line);
-
-// Loads all notes across the entire project into a newly allocated string (*result).
-// Caller must free(*result).
+// Loads all notes from the notes file into a newly allocated string (*result).
+// @notes_path: path to the notes file (local or global)
+// @result: pointer to store the loaded results — caller must free(*result)
 // Returns: CPIN_SUCCESS on success, CPIN_ERR_NOTE_NOT_FOUND if no notes exist
-cpin_error_t fileio_load_all(char** result);
+cpin_error_t fileio_load_all(const char* notes_path, char** result);
+
+// Deletes all notes matching file:line from the notes file (rewrites the file).
+// @file: path to the file containing the note
+// @line: line number where the note is located
+// @notes_path: path to the notes file (local or global)
+// Returns: CPIN_SUCCESS on success, or appropriate error code on failure
+cpin_error_t fileio_delete(char* file, char* line, const char* notes_path);
 
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5,9 +5,6 @@
 #include "errors.h"
 #include "fileio.h"
 
-#define CPIN_DIR   ".cpin"
-#define CPIN_NOTES ".cpin/notes"
-
 // ── note lifecycle ────────────────────────────────────────────────────────────
 
 cpin_note_t fileio_create_note(char* file, char* line, char* content) {
@@ -28,12 +25,19 @@ void fileio_note_free(cpin_note_t* note) {
 
 // ── storage helpers ───────────────────────────────────────────────────────────
 
-// Ensures the .cpin directory exists.
-cpin_error_t fileio_initialize(cpin_note_t* node) {
-    (void)node;
+// Ensures the directory containing notes_path exists.
+static cpin_error_t fileio_initialize(const char* notes_path) {
+    char dir[4096];
+    strncpy(dir, notes_path, sizeof(dir) - 1);
+    dir[sizeof(dir) - 1] = '\0';
+
+    char* slash = strrchr(dir, '/');
+    if (!slash) return CPIN_SUCCESS;
+    *slash = '\0';
+
     struct stat st = {0};
-    if (stat(CPIN_DIR, &st) == -1) {
-        if (mkdir(CPIN_DIR, 0755) != 0)
+    if (stat(dir, &st) == -1) {
+        if (mkdir(dir, 0755) != 0)
             return CPIN_ERR_STORAGE_INIT;
     }
     return CPIN_SUCCESS;
@@ -41,21 +45,21 @@ cpin_error_t fileio_initialize(cpin_note_t* node) {
 
 // ── single-file storage ───────────────────────────────────────────────────────
 //
-// Every note occupies exactly one line in .cpin/notes:
+// Every note occupies exactly one line in the notes file:
 //
 //   src/memory.c:87:potential leak here
 //
 // The file and line fields may not contain ':'.
 // The content field may contain ':' — we only split on the first two.
 
-// Appends a note to .cpin/notes.
-cpin_error_t fileio_save(cpin_note_t* node) {
+// Appends a note to the notes file.
+cpin_error_t fileio_save(cpin_note_t* node, const char* notes_path) {
     if (!node || !node->file || !node->content) return CPIN_ERR_INVALID_ARGS;
 
-    cpin_error_t err = fileio_initialize(node);
+    cpin_error_t err = fileio_initialize(notes_path);
     if (err != CPIN_SUCCESS) return err;
 
-    FILE* f = fopen(CPIN_NOTES, "a");
+    FILE* f = fopen(notes_path, "a");
     if (!f) return CPIN_ERR_WRITE_FAILED;
 
     if (node->line && node->line[0] != '\0')
@@ -92,11 +96,11 @@ static int parse_line(char* raw, char** out_file, char** out_line, char** out_co
 
 // Loads notes matching file (and optionally line) into a newly allocated
 // string (*result).  Caller must free(*result).
-cpin_error_t fileio_load(char* file, char* line, char** result) {
+cpin_error_t fileio_load(char* file, char* line, const char* notes_path, char** result) {
     if (!file || !result) return CPIN_ERR_INVALID_ARGS;
     *result = NULL;
 
-    FILE* f = fopen(CPIN_NOTES, "r");
+    FILE* f = fopen(notes_path, "r");
     if (!f) return CPIN_ERR_NOTE_NOT_FOUND;
 
     char buf[4096];
@@ -132,13 +136,13 @@ cpin_error_t fileio_load(char* file, char* line, char** result) {
     return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
 }
 
-// Loads all notes from .cpin/notes into a newly allocated string (*result).
+// Loads all notes from the notes file into a newly allocated string (*result).
 // Caller must free(*result).
-cpin_error_t fileio_load_all(char** result) {
+cpin_error_t fileio_load_all(const char* notes_path, char** result) {
     if (!result) return CPIN_ERR_INVALID_ARGS;
     *result = NULL;
 
-    FILE* f = fopen(CPIN_NOTES, "r");
+    FILE* f = fopen(notes_path, "r");
     if (!f) return CPIN_ERR_NOTE_NOT_FOUND;
 
     char buf[4096];
@@ -171,11 +175,11 @@ cpin_error_t fileio_load_all(char** result) {
     return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
 }
 
-// Deletes all notes matching file:line from .cpin/notes (rewrites the file).
-cpin_error_t fileio_delete(char* file, char* line) {
+// Deletes all notes matching file:line from the notes file (rewrites the file).
+cpin_error_t fileio_delete(char* file, char* line, const char* notes_path) {
     if (!file) return CPIN_ERR_INVALID_ARGS;
 
-    FILE* f = fopen(CPIN_NOTES, "r");
+    FILE* f = fopen(notes_path, "r");
     if (!f) return CPIN_ERR_NOTE_NOT_FOUND;
 
     // Read all raw lines into memory
@@ -197,7 +201,7 @@ cpin_error_t fileio_delete(char* file, char* line) {
     fclose(f);
 
     // Rewrite without matching lines
-    FILE* out = fopen(CPIN_NOTES, "w");
+    FILE* out = fopen(notes_path, "w");
     if (!out) {
         for (size_t i = 0; i < count; i++) free(lines[i]);
         free(lines);

--- a/src/main.c
+++ b/src/main.c
@@ -7,23 +7,49 @@
 
 static void usage(void) {
     printf("Usage:\n");
-    printf("  cpin add <file:line> \"<note>\"\n");
-    printf("  cpin list [file] [line]\n");
-    printf("  cpin remove <file:line>\n");
+    printf("  cpin add <file:line> \"<note>\" [--global]\n");
+    printf("  cpin list [file] [line] [--global]\n");
+    printf("  cpin remove <file:line> [--global]\n");
+}
+
+static const char* resolve_notes_path(int global) {
+    if (!global) return ".cpin/notes";
+
+    static char path[4096];
+    const char* home = getenv("HOME");
+    if (!home) {
+        fprintf(stderr, "Error: $HOME is not set\n");
+        exit(1);
+    }
+    snprintf(path, sizeof(path), "%s/.cpin/notes", home);
+    return path;
 }
 
 int main(int argc, char** argv) {
+    // Strip --global flag from argv before command dispatch
+    int global = 0;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--global") == 0) {
+            global = 1;
+            for (int j = i; j < argc - 1; j++)
+                argv[j] = argv[j + 1];
+            argc--;
+            break;
+        }
+    }
+
     if (argc < 2) {
         usage();
         return 1;
     }
 
+    const char* notes_path = resolve_notes_path(global);
     char* cmd = argv[1];
 
     // ── add ───────────────────────────────────────────────────────────────────
     if (!strcmp(cmd, "add")) {
         if (argc < 4) {
-            printf("Usage: cpin add <file:line> \"<note>\"\n");
+            printf("Usage: cpin add <file:line> \"<note>\" [--global]\n");
             return 1;
         }
 
@@ -42,7 +68,7 @@ int main(int argc, char** argv) {
         }
 
         cpin_note_t note = fileio_create_note(file, line, content);
-        err = fileio_save(&note);
+        err = fileio_save(&note, notes_path);
         fileio_note_free(&note);
 
         if (err != CPIN_SUCCESS) {
@@ -60,15 +86,15 @@ int main(int argc, char** argv) {
         cpin_error_t err;
 
         if (argc < 3) {
-            err = fileio_load_all(&result);
+            err = fileio_load_all(notes_path, &result);
             if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
-                printf("No notes found in this project\n");
+                printf("No notes found\n");
                 return 0;
             }
         } else {
             char* file = argv[2];
             char* line = (argc >= 4) ? argv[3] : NULL;
-            err = fileio_load(file, line, &result);
+            err = fileio_load(file, line, notes_path, &result);
             if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
                 printf("No notes found for %s%s%s\n",
                        file, line ? ":" : "", line ? line : "");
@@ -89,7 +115,7 @@ int main(int argc, char** argv) {
     // ── remove ────────────────────────────────────────────────────────────────
     if (!strcmp(cmd, "remove")) {
         if (argc < 3) {
-            printf("Usage: cpin remove <file:line>\n");
+            printf("Usage: cpin remove <file:line> [--global]\n");
             return 1;
         }
 
@@ -101,7 +127,7 @@ int main(int argc, char** argv) {
             return 1;
         }
 
-        err = fileio_delete(file, line);
+        err = fileio_delete(file, line, notes_path);
         if (err != CPIN_SUCCESS) {
             printf("Error: %s\n", error_to_string(err));
             return 1;


### PR DESCRIPTION
## What does this PR do?

Notes can now be stored in ~/.cpin/notes via --global, in addition to the default per-project .cpin/notes. fileio functions now accept a notes_path parameter instead of using hardcoded paths.

Closes #6

---

## Checklist

- [x] Builds without errors (`make`)
- [x] No compiler warnings (`-Wall -Wextra`)
- [x] Tested manually (paste example commands and output below)
- [x] Follows the code style in `CONTRIBUTING.md`
- [x] No memory leaks introduced (checked with `valgrind` or `AddressSanitizer` if applicable)

## Manual test

```bash
                                                                                     
cpin add src/main.c:10 "local note" 
cpin add src/main.c:20 "global note" --global
cpin list
src/main.c:10: local note
cpin list --global
src/main.c:20: global note
```