### PR TITLE
feat: add search command to grep notes by keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ cpin remove src/parser.c:42
 
 # Remove a note from the global store
 cpin remove src/parser.c:42 --global
+
+# Search a note (global flag is working like above)
+cpin search "personal" --global
+
 ```
 
 ### `--global` flag

--- a/include/fileio.h
+++ b/include/fileio.h
@@ -47,4 +47,11 @@ cpin_error_t fileio_load_all(const char* notes_path, char** result);
 // Returns: CPIN_SUCCESS on success, or appropriate error code on failure
 cpin_error_t fileio_delete(char* file, char* line, const char* notes_path);
 
+// Searches all notes for lines whose content contains the given keyword.
+// @keyword: substring to search for in note content
+// @notes_path: path to the notes file (local or global)
+// @result: pointer to store the matching results — caller must free(*result)
+// Returns: CPIN_SUCCESS on success, CPIN_ERR_NOTE_NOT_FOUND if no matches
+cpin_error_t fileio_search(const char* keyword, const char* notes_path, char** result);
+
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -175,6 +175,46 @@ cpin_error_t fileio_load_all(const char* notes_path, char** result) {
     return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
 }
 
+// Searches all notes for lines whose content contains keyword.
+// Returns matching lines as a newly allocated string (*result). Caller must free(*result).
+cpin_error_t fileio_search(const char* keyword, const char* notes_path, char** result) {
+    if (!keyword || !result) return CPIN_ERR_INVALID_ARGS;
+    *result = NULL;
+
+    FILE* f = fopen(notes_path, "r");
+    if (!f) return CPIN_ERR_NOTE_NOT_FOUND;
+
+    char buf[4096];
+    char* out = NULL;
+    size_t out_len = 0;
+
+    while (fgets(buf, sizeof(buf), f)) {
+        char tmp[4096];
+        strncpy(tmp, buf, sizeof(tmp) - 1);
+        tmp[sizeof(tmp) - 1] = '\0';
+
+        char *tok_file, *tok_line, *tok_content;
+        if (parse_line(tmp, &tok_file, &tok_line, &tok_content) != 0) continue;
+        if (!strstr(tok_content, keyword)) continue;
+
+        char display[4096];
+        int n = snprintf(display, sizeof(display), "%s:%s:%s\n",
+                         tok_file, tok_line, tok_content);
+        if (n <= 0) continue;
+
+        char* tmp_out = realloc(out, out_len + (size_t)n + 1);
+        if (!tmp_out) { free(out); fclose(f); return CPIN_ERR_WRITE_FAILED; }
+        out = tmp_out;
+        memcpy(out + out_len, display, (size_t)n);
+        out_len += (size_t)n;
+        out[out_len] = '\0';
+    }
+
+    fclose(f);
+    *result = out;
+    return (out_len > 0) ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
+}
+
 // Deletes all notes matching file:line from the notes file (rewrites the file).
 cpin_error_t fileio_delete(char* file, char* line, const char* notes_path) {
     if (!file) return CPIN_ERR_INVALID_ARGS;

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@ static void usage(void) {
     printf("  cpin add <file:line> \"<note>\" [--global]\n");
     printf("  cpin list [file] [line] [--global]\n");
     printf("  cpin remove <file:line> [--global]\n");
+    printf("  cpin search <keyword> [--global]\n");
 }
 
 static const char* resolve_notes_path(int global) {
@@ -134,6 +135,29 @@ int main(int argc, char** argv) {
         }
 
         printf("Note removed: %s:%s\n", file, line);
+        return 0;
+    }
+
+    // ── search ────────────────────────────────────────────────────────────────
+    if (!strcmp(cmd, "search")) {
+        if (argc < 3) {
+            printf("Usage: cpin search <keyword> [--global]\n");
+            return 1;
+        }
+
+        char* result = NULL;
+        cpin_error_t err = fileio_search(argv[2], notes_path, &result);
+        if (err == CPIN_ERR_NOTE_NOT_FOUND || !result) {
+            printf("No notes matching \"%s\"\n", argv[2]);
+            return 0;
+        }
+        if (err != CPIN_SUCCESS) {
+            printf("Error: %s\n", error_to_string(err));
+            return 1;
+        }
+
+        printf("%s", result);
+        free(result);
         return 0;
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds `cpin search <keyword> [--global]` which filters all notes by content substring and prints matching lines. Returns a friendly message when no notes match.

Closes #3

---

## Checklist

- [x] Builds without errors (`make`)
- [x] No compiler warnings (`-Wall -Wextra`)
- [x] Tested manually (paste example commands and output below)
- [x] Follows the code style in `CONTRIBUTING.md`
- [x] No memory leaks introduced (checked with `valgrind` or `AddressSanitizer` if applicable)
