### PR TITLE
Fix: Check whether the destination file exists before adding a note.

### DIFF
--- a/include/errors.h
+++ b/include/errors.h
@@ -11,6 +11,7 @@ typedef enum {
     CPIN_ERR_STORAGE_INIT,      // Failed to initialize storage directory
     CPIN_ERR_NOTE_NOT_FOUND,    // Specified node/entry not found
     CPIN_ERR_WRITE_FAILED,      // Failed to write to file or storage
+    CPIN_ERR_FILE_ACCESS,       // File access error
 } cpin_error_t;
 
 // Converts an error code to a human-readable string representation

--- a/include/fileio.h
+++ b/include/fileio.h
@@ -9,6 +9,11 @@ typedef struct {
     char* content;   // Actual content of the note
 } cpin_note_t;
 
+// Checks if the error code indicates 'No such file or directory'
+// @e: the errno value to check
+// Returns: true if the error is ENOENT, false otherwise
+#define FILE_NOT_FOUND(e) ((e) == ENOENT)
+
 // Creates a new cpin note structure with the specified file, line, and content
 // @file: path to the file where the note belongs
 // @line: line number in the file (can be NULL)
@@ -50,5 +55,10 @@ cpin_error_t fileio_delete(char* file, char* line);
 // Caller must free(*result).
 // Returns: CPIN_SUCCESS on success, CPIN_ERR_NOTE_NOT_FOUND if no notes exist
 cpin_error_t fileio_load_all(char** result);
+
+// Check if target file exist on disk
+// @file: path to the file to be checked on the disk
+// Returns: CPIN_SUCCESS on success, CPIN_ERR_FILE_NOT_EXIST if no file exist
+cpin_error_t fileio_file_exist(char* file);
 
 #endif

--- a/src/errors.c
+++ b/src/errors.c
@@ -10,6 +10,7 @@ const char* error_to_string(cpin_error_t error) {
         case CPIN_ERR_STORAGE_INIT:    return "failed to initialize .cpin storage";
         case CPIN_ERR_NOTE_NOT_FOUND:  return "note not found";
         case CPIN_ERR_WRITE_FAILED:    return "write failed";
+        case CPIN_ERR_FILE_ACCESS:      return "Cannot access file";
         default:                       return "unknown error";
     }
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -227,4 +228,22 @@ cpin_error_t fileio_delete(char* file, char* line) {
     fclose(out);
 
     return deleted ? CPIN_SUCCESS : CPIN_ERR_NOTE_NOT_FOUND;
+}
+
+// Checks if a file exists on disk.
+// Returns: CPIN_SUCCESS if file exists, CPIN_ERR_FILE_NOT_FOUND if not found,
+// or CPIN_ERR_FILE_ACCESS for other errors.
+cpin_error_t fileio_file_exist(char* file) {
+    if (!file) return CPIN_ERR_INVALID_ARGS;
+
+    FILE* found_file = fopen(file, "r");
+    if (found_file == NULL) {
+        if (FILE_NOT_FOUND(errno)) {
+            return CPIN_ERR_FILE_NOT_FOUND;
+        }
+        return CPIN_ERR_FILE_ACCESS;
+    }
+
+    fclose(found_file);
+    return CPIN_SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,12 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        err = fileio_file_exist(file);
+        if (err != CPIN_SUCCESS) {
+            printf("Error: %s\n", error_to_string(err));
+            return 1;
+        }
+
         cpin_note_t note = fileio_create_note(file, line, content);
         err = fileio_save(&note);
         fileio_note_free(&note);


### PR DESCRIPTION
## What does this PR do?

The code provided fix this [issue](https://github.com/jonaebel/cpin/issues/15) by adding validation within the addition logic in main.c. It calls a fileio_file_exist method that trys to open the destination file if possible. 

Closes #

---

## Checklist

- [X] Builds without errors (`make`)
- [X] No compiler warnings (`-Wall -Wextra`)
- [X] Tested manually (paste example commands and output below)
- [X] Follows the code style in `CONTRIBUTING.md`
- [X] No memory leaks introduced (checked with `valgrind` or `AddressSanitizer` if applicable)

## Manual test

```bash
$ ./cpin add src/doesntexist.c:10 "why does this loop start at 1?"
Error: file not found
$ ./cpin add src/errors.c:10 "why does this loop start at 1?"
Note added: src/errors.c:10
```

## Notes for reviewers

I'm not sure if you would prefer to create a new error type instead of using CPIN_ERR_FILE_NOT_FOUND, for example, “file does not exist”. I used CPIN_ERR_FILE_NOT_FOUND because I think it is the most similar to the error we are dealing with.

If you would like to modify this or any other part of my proposal, please let me know.

Thanks!.
