### PR TITLE
feat: enhance Makefile with improved compilation flags and add valgrind target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = clang
-CFLAGS = -Wall -Wextra -g -Iinclude
+CFLAGS = -Wall -Wextra -g -pedantic -std=c99 -D_POSIX_C_SOURCE=200809L -Iinclude
 
 all:
 	$(CC) $(CFLAGS) src/*.c -o cpin
@@ -9,6 +9,9 @@ clean:
 
 run:
 	./cpin
+
+valgrind:
+	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./cpin
 
 install: all
 	cp cpin /usr/local/bin/cpin


### PR DESCRIPTION
## What does this PR do?

I made a small improvement to the makefile, adding -pedantic -std=c99 and an option to run valgrind.
The CONTRIBUTING.md it specifies that we must to comply with C99 standard. Addind  -pedantic -std=c99 help us see warnings related to the C99 standard. We also need -D_POSIX_C_SOURCE=200809L to use posix functions.

To check for memory leaks now, we just need to run make valgrind.

## Checklist

- [X] Builds without errors (`make`)
- [X] No compiler warnings (`-Wall -Wextra`)
- [X] Tested manually (paste example commands and output below)
- [X] Follows the code style in `CONTRIBUTING.md`
- [X] No memory leaks introduced (checked with `valgrind` or `AddressSanitizer` if applicable)

## Manual test

```bash

# Make with clang
$ make 
clang -Wall -Wextra -g -pedantic -std=c99 -D_POSIX_C_SOURCE=200809L -Iinclude src/*.c -o cpin

# Make with gcc
$ make
gcc -Wall -Wextra -g -pedantic -std=c99 -D_POSIX_C_SOURCE=200809L -Iinclude src/*.c -o cpin

# Valgrind
$ make valgrind
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./cpin
==22053== Memcheck, a memory error detector
==22053== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==22053== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==22053== Command: ./cpin
==22053== 
Usage:
  cpin add <file:line> "<note>" [--global]
  cpin list [file] [line] [--global]
  cpin remove <file:line> [--global]
  cpin search <keyword> [--global]
  cpin export [--json|--md] [--global]
==22053== 
==22053== HEAP SUMMARY:
==22053==     in use at exit: 0 bytes in 0 blocks
==22053==   total heap usage: 1 allocs, 1 frees, 1,024 bytes allocated
==22053== 
==22053== All heap blocks were freed -- no leaks are possible
==22053== 
==22053== For lists of detected and suppressed errors, rerun with: -s
==22053== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
make: *** [Makefile:14: valgrind] Error 1

```

## Notes for reviewers

I tested these changes on Arch Linux with gcc and clang. I haven't been able to test them on macOs, but I think they should work fine there too.
If you think this change is unnecessary or needs improvement, please let me know!